### PR TITLE
fix event stream

### DIFF
--- a/events.go
+++ b/events.go
@@ -82,6 +82,10 @@ func (e *EventListener) NextStateChanged() (StateChangedEvent, error) {
 		if len(line) > 6 && string(line[:6]) == "data: " {
 			jsonData := line[6:]
 
+			if string(jsonData) == "ping\n" {
+				continue
+			}
+
 			var eventTypeFinder struct {
 				EventType string `json:"event_type"`
 			}

--- a/events.go
+++ b/events.go
@@ -23,7 +23,7 @@ func (a *Access) ListenEvents() (*EventListener, error) {
 		return nil, err
 	}
 
-	req.Header.Set("x-ha-access", a.password)
+	a.authorizeRequest(req)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/events.go
+++ b/events.go
@@ -2,6 +2,7 @@ package hass
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -14,11 +15,15 @@ type EventListener struct {
 }
 
 func (a *Access) ListenEvents() (*EventListener, error) {
-	client := &http.Client{
-		Timeout: time.Second * 10,
-	}
+	ctx, _ := context.WithTimeout(context.Background(), time.Second*10)
 
-	req, err := http.NewRequest("GET", a.host+"/api/stream", nil)
+	return a.ListenEventsWithContext(ctx)
+}
+
+func (a *Access) ListenEventsWithContext(ctx context.Context) (*EventListener, error) {
+	client := http.DefaultClient
+
+	req, err := http.NewRequestWithContext(ctx, "GET", a.host+"/api/stream", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/request.go
+++ b/request.go
@@ -64,17 +64,7 @@ func (a *Access) httpGet(path string, v interface{}) error {
 		return err
 	}
 
-	if a.password != "" {
-		req.Header.Set("x-ha-access", a.password)
-	}
-
-	if a.token != "" {
-		req.Header.Set("X-HASSIO-KEY", a.token)
-	}
-
-	if a.bearertoken != "" {
-		req.Header.Set("Authorization", a.bearertoken)
-	}
+	a.authorizeRequest(req)
 
 	success := false
 	for i := 0; i < 3; i++ {
@@ -128,17 +118,7 @@ func (a *Access) httpPost(path string, v interface{}) error {
 		}
 	}
 
-	if a.password != "" {
-		req.Header.Set("x-ha-access", a.password)
-	}
-
-	if a.token != "" {
-		req.Header.Set("X-HASSIO-KEY", a.token)
-	}
-
-	if a.bearertoken != "" {
-		req.Header.Set("Authorization", a.bearertoken)
-	}
+	a.authorizeRequest(req)
 
 	var err error
 	success := false
@@ -161,4 +141,18 @@ func (a *Access) httpPost(path string, v interface{}) error {
 	}
 
 	return err
+}
+
+func (a *Access) authorizeRequest(req *http.Request) {
+	if a.password != "" {
+		req.Header.Set("x-ha-access", a.password)
+	}
+
+	if a.token != "" {
+		req.Header.Set("X-HASSIO-KEY", a.token)
+	}
+
+	if a.bearertoken != "" {
+		req.Header.Set("Authorization", a.bearertoken)
+	}
 }


### PR DESCRIPTION
Request authentication of the event stream http call was missing the token options.

Also there's a new function `ListenEventsWithContext` allowing the user to use `context.Context` with a custom timeout or other means to cancel the stream instead of the fixed 10 second timeout. The existing `ListenEvents` function uses this new function with a timeout Context.