### PR TITLE
support arbitrary state attributes

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -26,18 +26,14 @@ func (a *Access) CheckAPI() error {
 
 // State is the struct for an object state
 type State struct {
-	Attributes struct {
-		Auto         bool   `json:"auto"`
-		FriendlyName string `json:"friendly_name"`
-		Hidden       bool   `json:"hidden"`
-		Order        int    `json:"order"`
-		AssumedState bool   `json:"assumed_state"`
-	} `json:"attributes"`
-	EntityID    string    `json:"entity_id"`
-	LastChanged time.Time `json:"last_changed"`
-	LastUpdated time.Time `json:"last_updated"`
-	State       string    `json:"state"`
+	Attributes  StateAttributes `json:"attributes"`
+	EntityID    string          `json:"entity_id"`
+	LastChanged time.Time       `json:"last_changed"`
+	LastUpdated time.Time       `json:"last_updated"`
+	State       string          `json:"state"`
 }
+
+type StateAttributes map[string]interface{}
 
 // States is an array of State objects
 type States []State

--- a/events.go
+++ b/events.go
@@ -42,31 +42,19 @@ type StateChangedEvent struct {
 	TimeFired time.Time `json:"time_fired"`
 	Data      struct {
 		OldState struct {
-			EntityID    string    `json:"entity_id"`
-			State       string    `json:"state"`
-			LastChanged time.Time `json:"last_changed"`
-			LastUpdated time.Time `json:"last_updated"`
-			Attributes  struct {
-				EntityID     []string `json:"entity_id"`
-				Order        int      `json:"order"`
-				Hidden       bool     `json:"hidden"`
-				FriendlyName string   `json:"friendly_name"`
-				Auto         bool     `json:"auto"`
-			} `json:"attributes"`
+			EntityID    string          `json:"entity_id"`
+			State       string          `json:"state"`
+			LastChanged time.Time       `json:"last_changed"`
+			LastUpdated time.Time       `json:"last_updated"`
+			Attributes  StateAttributes `json:"attributes"`
 		} `json:"old_state"`
 		EntityID string `json:"entity_id"`
 		NewState struct {
-			EntityID    string    `json:"entity_id"`
-			State       string    `json:"state"`
-			LastChanged time.Time `json:"last_changed"`
-			LastUpdated time.Time `json:"last_updated"`
-			Attributes  struct {
-				EntityID     []string `json:"entity_id"`
-				Order        int      `json:"order"`
-				Hidden       bool     `json:"hidden"`
-				FriendlyName string   `json:"friendly_name"`
-				Auto         bool     `json:"auto"`
-			} `json:"attributes"`
+			EntityID    string          `json:"entity_id"`
+			State       string          `json:"state"`
+			LastChanged time.Time       `json:"last_changed"`
+			LastUpdated time.Time       `json:"last_updated"`
+			Attributes  StateAttributes `json:"attributes"`
 		} `json:"new_state"`
 	} `json:"data"`
 }


### PR DESCRIPTION
The `attributes` property of `state` varies widely between different device classes. Defining it as an untyped `map[string]interface{}` allows the user to access all the values.